### PR TITLE
Restore US RegEx and remove the "375" that was in its place.

### DIFF
--- a/data/phone_countries.yml
+++ b/data/phone_countries.yml
@@ -178,7 +178,7 @@
   :char_3_code: "GY"
   :name: Guyana
   :international_dialing_prefix: "001"
-  :area_code: "21[89]|2(2[3567]|31|6[023])|3(28|3[34])|44[14]|455|777|6[0-9]{2}"
+  :area_code: "21[89]|2(2[3567]|31|6[023])|3(28|3[34])|44[14]|455|777|6\\d{2}"
   :local_number_format: "\\d{4}"
   :mobile_format: "6\\d{6}"
   :number_format: "\\d{7}"
@@ -738,7 +738,7 @@
   :char_3_code: "MG"
   :name: Madagascar
   :international_dialing_prefix: "00"
-"1a":
+"1a": 
   :country_code: "1"
   :national_dialing_prefix: "1"
   :char_2_code: "1"
@@ -857,7 +857,7 @@
   :char_3_code: "AF"
   :name: Afghanistan
   :international_dialing_prefix: "00"
-  :area_code: "7|[2-9][0-9]"
+  :area_code: "7|[2-9]\\d"
   :local_number_format: "\\d{7,8}"
   :mobile_format: "7\\d{8}"
   :number_format: "\\d{9}"
@@ -942,7 +942,7 @@
   :char_2_code: None
   :char_3_code: "TW"
   :name: Taiwan, Province Of China
-  :international_dialing_prefix: "2"
+  :international_dialing_prefix: "002"
 "378": 
   :country_code: "378"
   :national_dialing_prefix: None
@@ -1366,8 +1366,8 @@
   :char_2_code: "0"
   :char_3_code: "SE"
   :name: Sweden
-  :international_dialing_prefix: "0"
-  :area_code: "900|1[013689]|2[0136]|3[1356]|4[0246]|54|6[03]|7[01236]|8|9[09]|1[2457][0-9]|2[2457-9][0-9]|3[0247-9][0-9]|4[1357-9][0-9]|5[0-35-9][0-9]|6[124-9][0-9]|74[0-9]|9[1-8][0-9]"
+  :international_dialing_prefix: "00"
+  :area_code: "900|1[013689]|2[0136]|3[1356]|4[0246]|54|6[03]|7[01236]|8|9[09]|1[2457]\\d|2[2457-9]\\d|3[0247-9]\\d|4[1357-9]\\d|5[0-35-9]\\d|6[124-9]\\d|74\\d|9[1-8]\\d"
   :local_number_format: "\\d{5,8}"
   :mobile_format: "7\\d{8}"
   :number_format: "\\d{7,10}"
@@ -1377,7 +1377,7 @@
   :char_2_code: None
   :char_3_code: "NO"
   :name: Norway
-  :international_dialing_prefix: "0"
+  :international_dialing_prefix: "00"
   :area_code: "23|3[378]|6[29]|77|4|5|7|9|\\d{1,2}"
   :local_number_format: "\\d{6,7}"
   :mobile_format: "[49]\\d{7}"


### PR DESCRIPTION
Restore US RegEx and delete "375" that was in its place.

Optimise several RegEx patterns. Fix several international_dialing_prefix items.
