### PR TITLE
require all of active_model to avoid lazy-loading errors

### DIFF
--- a/lib/phonie/phone.rb
+++ b/lib/phonie/phone.rb
@@ -1,6 +1,4 @@
-require 'active_model/naming'
-require 'active_model/translation'
-require 'active_model/validations'
+require 'active_model'
 
 # An object representing a phone number.
 #


### PR DESCRIPTION
as per https://github.com/rails/rails/pull/8312 and https://github.com/rails/rails/issues/5768
