### PR TITLE
Allow access to all attributes from data file

### DIFF
--- a/lib/phonie/country.rb
+++ b/lib/phonie/country.rb
@@ -1,12 +1,12 @@
 module Phonie
-  class Country < Struct.new(:name, :country_code, :char_2_code, :iso_3166_code, :area_code, :local_number_format, :mobile_format, :full_number_length, :number_format)
+  class Country < Struct.new(:name, :country_code, :char_2_code, :iso_3166_code, :area_code, :local_number_format, :mobile_format, :full_number_length, :number_format, :extra)
     def self.load
       data_file = File.join(File.dirname(__FILE__), 'data', 'phone_countries.yml')
 
       all = []
       YAML.load(File.read(data_file)).each do |c|
         next unless c[:area_code] && c[:local_number_format]
-        all << Country.new(c[:name], c[:country_code], c[:char_2_code], c[:iso_3166_code], c[:area_code], c[:local_number_format], c[:mobile_format], c[:full_number_length], c[:number_format])
+        all << Country.new(c[:name], c[:country_code], c[:char_2_code], c[:iso_3166_code], c[:area_code], c[:local_number_format], c[:mobile_format], c[:full_number_length], c[:number_format], c)
       end
       all
     end

--- a/test/country_test.rb
+++ b/test/country_test.rb
@@ -24,4 +24,9 @@ class CountryTest < Phonie::TestCase
     assert_equal "Norway", countries.first.name
   end
 
+  def test_extra
+    country = Phonie::Country.find_by_name('Canada')
+    assert_equal 'Canada', country.extra[:name]
+    assert_equal '011', country.extra[:international_dialing_prefix]
+  end
 end


### PR DESCRIPTION
Add an `extra` attribute which returns a hash of all the attributes from the data file.
