### PR TITLE
add Kuwait w/test, and allow for blank area codes

### DIFF
--- a/lib/phonie/data/phone_countries.yml
+++ b/lib/phonie/data/phone_countries.yml
@@ -485,11 +485,15 @@
   :number_format: '[4]\d{8}|[1-9]\d{7}'
 -
   :country_code: '965'
-  :national_dialing_prefix: None
+  :national_dialing_prefix: '0'
   :char_2_code: None
   :iso_3166_code: KW
   :name: Kuwait
   :international_dialing_prefix: '00'
+  :area_code: ''
+  :local_number_format: \d{8}
+  :number_format: \d{8}
+  :mobile_format: ''
 -
   :country_code: '371'
   :national_dialing_prefix: '8'

--- a/lib/phonie/phone.rb
+++ b/lib/phonie/phone.rb
@@ -37,7 +37,7 @@ module Phonie
 
     include ActiveModel::Validations
     validates :country_code, :presence => true
-    validates :area_code, :presence => true
+    validates :area_code, :presence => {:unless => lambda { |p| p.area_code == "" } }
     validates :number, :presence => true
 
     def initialize(*hash_or_args)

--- a/test/countries/kw_test.rb
+++ b/test/countries/kw_test.rb
@@ -1,0 +1,8 @@
+require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+
+## Kuwait
+class KWTest < Phonie::TestCase
+  def test_local
+    parse_test('+96566135555',  '965', '',  '66135555', 'Kuwait', false)
+  end
+end


### PR DESCRIPTION
### WHAT
- adds Kuwait to country list by giving it an `:area_code` and `:local_number_format`
- add blank `:mobile_number` to Kuwait so it doesn't default `is_mobile?` to true
- add a test for Kuwait
- add an exception to the `area_code` presence validation, where it can equal a blank string. Kuwait apparently doesn't have area codes (http://en.wikipedia.org/wiki/Telephone_numbers_in_Kuwait).
