### PR TITLE
Add 5 in front of Mauritius numbers

### DIFF
--- a/lib/phonie/data/phone_countries.yml
+++ b/lib/phonie/data/phone_countries.yml
@@ -587,9 +587,9 @@
   :iso_3166_code: MU
   :name: Mauritius
   :international_dialing_prefix: '00'
-  :area_code: '5[1-9]\d{2}'
+  :area_code: '5?[1-9]\d{2}'
   :local_number_format: \d{4}
-  :number_format: \d{8}
+  :number_format: \d{7,8}
   :mobile_format: (57\d{6}|587\d{5}|59\d{6}|5421\d{4}|5422\d{4}|5423\d{4}|5428\d{4}|5429\d{4}|549\d{5}|525\d{5})
 -
   :country_code: '994'

--- a/test/countries/mu_test.rb
+++ b/test/countries/mu_test.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 ## Mauritius
 class MUTest < Phonie::TestCase
   def test_local
-    parse_test('+23054037000',  '230', '5403',  '7000', 'Mauritius', false)
+    parse_test('+2304037000',  '230', '403',  '7000', 'Mauritius', false)
   end
 
   def test_mobile


### PR DESCRIPTION
Change happened on 1 September 2013
