### PR TITLE
Reimplement ability to customize named formatters

### DIFF
--- a/Readme.rdoc
+++ b/Readme.rdoc
@@ -33,6 +33,7 @@ Alternatively Phonie can be configured via a block
     Phonie.configure do |config|
       config.default_country_code = '385'
       config.default_area_code = '47'
+      config.add_custom_named_format :short, '%A/%n1-%n2'
     end
 
     Phonie::Phone.parse '451-588'
@@ -64,13 +65,13 @@ When given a string, it interpolates the string with the following fields:
     pn.format("%A/%f-%l") # => "091/512-5486"
     pn.format("+ %c (%a) %n") # => "+ 385 (91) 5125486"
 
-When given a symbol it is used as a lookup for the format in the <tt>Phonie::Phone.named_formats</tt> hash.
+When given a symbol it is used as a lookup for the format in <tt>Phonie::Formatter</tt>.
     pn.format(:europe) # => "+385 (0) 91 512 5486"
-    pn.format(:us) # => "(234) 123 4567"    
+    pn.format(:us) # => "(234) 123 4567"
     pn.format(:default_with_extension) # => "+3851234567x143"
 
 You can add your own custom named formats like so:
-    Phonie::Phone.named_formats[:short] = '%A/%n1-%n2'
+    Phonie.configuration.add_custom_named_format :short, '%A/%n1-%n2'
     pn.format(:short) # => 091/512-5486
 
 == ActiveModel validator
@@ -95,7 +96,7 @@ Add definitions for more countries
 Currently tested on:
 [AE] UAE
 [AF] Afghanistan
-[AL] Albania 
+[AL] Albania
 [AM] Armenia
 [AR] Argentina
 [AT] Austria
@@ -186,7 +187,7 @@ Currently tested on:
 = How you can contribute
 More testing is needed to add support for missing countries, and improve support for tested countries. In many cases only minimal testing is done on area codes, local number formats and number length where more exact matching is possible.
 
-The best places to start is to read through the country tests and data/phone_countries.rb 
+The best places to start is to read through the country tests and data/phone_countries.rb
 
 = Other libraries
 This is based off a fork of the Phone gem (https://github.com/carr/phone), and was extensively modified for better support of country detection, and supports far more countries.

--- a/lib/phonie/configuration.rb
+++ b/lib/phonie/configuration.rb
@@ -5,10 +5,19 @@ module Phonie
     include Singleton
 
     attr_accessor :data_file_path, :default_area_code, :default_country_code, :n1_length
- 
+
     def initialize
       @data_file_path = File.join(File.dirname(__FILE__), 'data', 'phone_countries.yml')
       @n1_length = 3
+      @named_formats = {}
+    end
+
+    def add_custom_named_format(name, format_string)
+      @named_formats[name.to_sym] = format_string
+    end
+
+    def custom_named_formats
+      @named_formats
     end
   end
 

--- a/lib/phonie/formatter.rb
+++ b/lib/phonie/formatter.rb
@@ -18,7 +18,7 @@ module Phonie
 
     def initialize(params)
       @phone_number = params[:phone_number]
-      
+
       format = params[:format]
       @format = if format.respond_to?(:gsub)
         format
@@ -31,12 +31,7 @@ module Phonie
     end
 
     def self.named_formats
-      {
-        default: "+%c%a%n",
-        default_with_extension: "+%c%a%nx%x",
-        europe: '+%c (0) %a %f %l',
-        us: "(%a) %f-%l"
-      }
+      default_named_formats.merge(Phonie.configuration.custom_named_formats)
     end
 
     def to_s
@@ -49,6 +44,17 @@ module Phonie
         gsub("%f", pn.number1.to_s).
         gsub("%l", pn.number2.to_s).
         gsub("%x", pn.extension.to_s)
+    end
+
+    private
+
+    def self.default_named_formats
+      {
+        default: "+%c%a%n",
+        default_with_extension: "+%c%a%nx%x",
+        europe: '+%c (0) %a %f %l',
+        us: "(%a) %f-%l"
+      }
     end
   end
 end

--- a/test/phone_test.rb
+++ b/test/phone_test.rb
@@ -96,6 +96,12 @@ class PhoneTest < Phonie::TestCase
     assert_equal '+385 (0) 91 512 5486', pn.format(:europe)
   end
 
+  def test_format_with_custom_symbol_specifier
+    Phonie.configuration.add_custom_named_format :internal, 'ext.%x'
+    pn = Phonie::Phone.new '5125486', '91', '385', '1234'
+    assert_equal 'ext.1234', pn.format(:internal)
+  end
+
   def test_valid
     assert Phonie::Phone.valid?('915125486', :country_code => '385')
     assert Phonie::Phone.valid?('385915125486')


### PR DESCRIPTION
This brings the implementation back in line with what the Readme
indicates is possible.

This regression was introduced in 7c88730.

@dlindahl authored a fix in https://github.com/wmoxam/phonie/pull/36, this one is more fitting with the conventions established in Phonie 3.0
