### PR TITLE
Update brazil rules for 11 digit numbers

### DIFF
--- a/lib/phonie/data/phone_countries.yml
+++ b/lib/phonie/data/phone_countries.yml
@@ -184,9 +184,9 @@
   :name: Brazil
   :international_dialing_prefix: '00'
   :area_code: \d{2}
-  :local_number_format: \d{7,8}
+  :local_number_format: \d{7,9}
   :mobile_format: 11[6789]\d{7}
-  :number_format: \d{10}
+  :number_format: \d{10,11}
 -
   :country_code: '253'
   :national_dialing_prefix: None


### PR DESCRIPTION
I came across an 11 digit Brazilian number of the form `+55 21 000 000000` in my application. This pull request updates the Brazil rules for allow for 10 and 11 digit numbers.
