### PR TITLE
Support for Singapore

### DIFF
--- a/lib/phonie/data/phone_countries.yml
+++ b/lib/phonie/data/phone_countries.yml
@@ -913,6 +913,10 @@
   :char_2_code: None
   :iso_3166_code: SG
   :name: Singapore
+  :area_code: 3|6|8|9
+  :number_format: \d{8}
+  :mobile_format: (8|9)\d{7}
+  :local_number_format: \d{7}
   :international_dialing_prefix: '000'
 -
   :country_code: '290'

--- a/test/countries/sg_test.rb
+++ b/test/countries/sg_test.rb
@@ -1,0 +1,13 @@
+require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+
+## Singapore
+class SGTest < Phonie::TestCase
+  def test_local
+    parse_test('+6568801234',  '65', '6',  '8801234', 'Singapore', false)
+  end
+
+  def test_mobile
+    parse_test('+6591233132',  '65', '9',  '1233132', 'Singapore', true)
+  end
+end
+


### PR DESCRIPTION
This completes the entry for Singapore so it's a valid country, and includes a test.

NB: Singapore doesn't have area codes, but we can treat the first number as an area code to pass our validation.
