### PR TITLE
Support for Hong Kong

### DIFF
--- a/Readme.rdoc
+++ b/Readme.rdoc
@@ -138,6 +138,7 @@ Currently tested on:
 [GT] Guatemala
 [GU] Guam
 [GY] Guyana
+[HK] Hong Kong
 [HR] Croatia
 [HU] Hungary
 [IE] Ireland

--- a/lib/phonie/data/phone_countries.yml
+++ b/lib/phonie/data/phone_countries.yml
@@ -608,6 +608,10 @@
   :char_2_code: None
   :iso_3166_code: HK
   :name: Hong Kong
+  :area_code: 2|3|5|6|7|8|9
+  :number_format: \d{8}
+  :mobile_format: (5|6|7|9)\d{7}
+  :local_number_format: \d{7}
   :international_dialing_prefix: '001'
 -
   :country_code: '372'

--- a/test/countries/hk_test.rb
+++ b/test/countries/hk_test.rb
@@ -1,0 +1,13 @@
+require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+
+## Hong Kong
+class HKTest < Phonie::TestCase
+  def test_local
+    parse_test('+85225555555', '852', '2', '5555555', 'Hong Kong', false)
+  end
+
+  def test_mobile
+    parse_test('+85265555555', '852', '6', '5555555', 'Hong Kong', true)
+  end
+end
+


### PR DESCRIPTION
This completes Hong Kong support, and includes a test.

Like [Singapore](https://github.com/wmoxam/phonie/pull/40), HK doesn't have area codes. So I just pulled the first number (which designates the type of phone number) out as the area code, to pass the area code validation.
