### PR TITLE
Fix for Thailand mobile numbers

### DIFF
--- a/lib/phonie/data/phone_countries.yml
+++ b/lib/phonie/data/phone_countries.yml
@@ -1045,8 +1045,8 @@
   :international_dialing_prefix: '001'
   :area_code: '(2|[3-9]\d)'
   :local_number_format: '\d{6,7}'
-  :number_format: '\d{8}'
-  :mobile_format: '([6,8,9][0-9])\d{6}'
+  :number_format: '\d{8,9}'
+  :mobile_format: '[6,8,9]\d{7,8}'
 -
   :country_code: '886'
   :national_dialing_prefix: None

--- a/test/countries/th_test.rb
+++ b/test/countries/th_test.rb
@@ -8,6 +8,7 @@ class THTest < Phonie::TestCase
   end
 
   def test_mobile
+    parse_test('+66940734567', '66', '94',  '0734567', 'Thailand', true)
     parse_test('+6687342563',  '66', '87',  '342563', 'Thailand', true)
   end
 end


### PR DESCRIPTION
This is a fix for Thailand mobile numbers. They can be 9 digits (excluding the leading `0`). Also removing parens that looked pointless.
