### PR TITLE
Remove personal numbers from GB mobile regexp

### DIFF
--- a/lib/phonie/data/phone_countries.yml
+++ b/lib/phonie/data/phone_countries.yml
@@ -1490,7 +1490,7 @@
   :international_dialing_prefix: '00'
   :area_code: 2[03489]|11[3-8]|1[2-69]1|1(3873|5(242|39[456])|697[347]|768[347]|9467)|1[2-9]\d{2}|3[0347]\d|500|5[56]|70|7([45789]\d{2}|624)|8(0[08]|4[2-5]|7[0-3])|9[018]\d
   :local_number_format: \d{4,8}
-  :mobile_format: '7[^06]\d{8}'
+  :mobile_format: '7[1-9]\d{8}'
   :number_format: \d{9,10}
 -
   :country_code: '242'

--- a/lib/phonie/data/phone_countries.yml
+++ b/lib/phonie/data/phone_countries.yml
@@ -1490,7 +1490,7 @@
   :international_dialing_prefix: '00'
   :area_code: 2[03489]|11[3-8]|1[2-69]1|1(3873|5(242|39[456])|697[347]|768[347]|9467)|1[2-9]\d{2}|3[0347]\d|500|5[56]|70|7([45789]\d{2}|624)|8(0[08]|4[2-5]|7[0-3])|9[018]\d
   :local_number_format: \d{4,8}
-  :mobile_format: 7\d{9}
+  :mobile_format: '7[^06]\d{8}'
   :number_format: \d{9,10}
 -
   :country_code: '242'

--- a/test/countries/gb_test.rb
+++ b/test/countries/gb_test.rb
@@ -259,4 +259,8 @@ class GBTest < Phonie::TestCase
     parse_test('+44 873 1570123', '44', '873', '1570123')
   end
 
+  def test_personal
+    parse_test('+44 70 0585 0070', '44', '70', '05850070', 'United Kingdom', false)
+  end
+
 end


### PR DESCRIPTION
In the UK 070 numbers are reserved for 'Personal Numbering'[0] and,
despite beginning with 07, are not necessarily mobile.

[0] http://en.wikipedia.org/wiki/Personal_numbering