### PR TITLE
Add 052 as a valid UAE area code

### DIFF
--- a/lib/phonie/data/phone_countries.yml
+++ b/lib/phonie/data/phone_countries.yml
@@ -1145,7 +1145,7 @@
   :iso_3166_code: AE
   :name: United Arab Emirates
   :international_dialing_prefix: '00'
-  :area_code: 2|3|6|9|48|5[0568]|7[07]|88|4|7
+  :area_code: 2|3|6|9|48|5[02568]|7[07]|88|4|7
   :local_number_format: \d{7}
   :mobile_format: (50|55|56)\d{7}
   :number_format: \d{8,9}


### PR DESCRIPTION
According to [wikipedia](http://en.wikipedia.org/wiki/List_of_mobile_phone_number_series_by_country), valid area codes for UAE are 050, 056, 055, 052.

I've added 052 which was missing and is definitely valid, but didn't remove 058 cause I'm not 100% if it's valid or not.