### PR TITLE
Add support for Indonesia (mobile only)

### DIFF
--- a/lib/phonie/data/phone_countries.yml
+++ b/lib/phonie/data/phone_countries.yml
@@ -714,6 +714,9 @@
   :iso_3166_code: ID
   :name: Indonesia
   :international_dialing_prefix: '001'
+  :area_code: 8\d\d
+  :number_format: 8\d{8,10}
+  :local_number_format: \d{6,8}
 -
   :country_code: '260'
   :national_dialing_prefix: '0'

--- a/test/countries/id_test.rb
+++ b/test/countries/id_test.rb
@@ -1,0 +1,29 @@
+require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+
+## Indonesia
+class IDTest < Phonie::TestCase
+  def test_mobile
+    parse_test('6281311122233', '62', '813', '11122233', "Indonesia", true)
+  end
+
+  def test_long_with_default_country_code
+    Phonie.configuration.default_country_code = '62'
+    parse_test('81311122233', '62', '813', '11122233')
+  end
+
+  def test_short_with_default_country_code_and_area_code
+    Phonie.configuration.default_country_code = '62'
+    Phonie.configuration.default_area_code = '813'
+    parse_test('11122233', '62', '813', '11122233')
+  end
+
+  def test_lengths
+    Phonie.configuration.default_country_code = '62'
+
+    phone = Phonie::Phone.parse("81311122233")
+    assert phone
+
+    phone = Phonie::Phone.parse("813111222334")
+    assert_nil phone
+  end
+end


### PR DESCRIPTION
Basic Indonesian mobile phone numbers support, based on this [wiki page](https://en.wikipedia.org/wiki/List_of_mobile_phone_number_series_by_country)

Not 100% precise (precision sacrificed in favour of implementation simplicity)