### PR TITLE
Adds Support for Cuba

### DIFF
--- a/lib/phonie/data/phone_countries.yml
+++ b/lib/phonie/data/phone_countries.yml
@@ -1890,6 +1890,10 @@
   :char_2_code: '0'
   :iso_3166_code: CU
   :name: Cuba
+  :area_code: '2\d{1}|3\d{1}|4\d{1}|5|7'
+  :mobile_format: '5\d{7}'
+  :number_format: '\d{8}'
+  :local_number_format: '\d{6,7}'
   :international_dialing_prefix: '119'
 -
   :country_code: '211'

--- a/test/countries/cu_test.rb
+++ b/test/countries/cu_test.rb
@@ -1,0 +1,13 @@
+require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+
+## Fiji
+class CUTest < Phonie::TestCase
+  def test_local
+    parse_test('+5378346100',  '53', '7',  '8346100', 'Cuba', false)
+  end
+
+  def test_mobile
+    parse_test('+5353478134', '53', '5', '3478134', 'Cuba', true)
+  end
+
+end


### PR DESCRIPTION
Based on https://en.wikipedia.org/wiki/Telephone_numbers_in_Cuba