### PR TITLE
Add tests for, and fix, Macedonia's phone formats.

### DIFF
--- a/lib/phonie/data/phone_countries.yml
+++ b/lib/phonie/data/phone_countries.yml
@@ -1741,6 +1741,10 @@
   :iso_3166_code: MK
   :name: Macedonia, the Former Yugoslav Republic Of
   :international_dialing_prefix: '00'
+  :area_code: '[27]|[34]\d|[58]\d\d'
+  :local_number_format: '\d{5,7}'
+  :mobile_format: '7\d+'
+  :number_format: '\d{8}'
 -
   :country_code: '670'
   :national_dialing_prefix: None

--- a/test/countries/mk_test.rb
+++ b/test/countries/mk_test.rb
@@ -1,0 +1,13 @@
+require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+
+## Macedonia
+class MKTest < Phonie::TestCase
+  def test_local
+    parse_test('+38921234567', '389', '2', '1234567', 'Macedonia, the Former Yugoslav Republic Of', false)
+    parse_test('+38931234567', '389', '31', '234567', 'Macedonia, the Former Yugoslav Republic Of', false)
+  end
+
+  def test_mobile
+    parse_test('+38971234567', '389', '7', '1234567', 'Macedonia, the Former Yugoslav Republic Of', true)
+  end
+end


### PR DESCRIPTION
Calling `Phonie::Phone.parse` on a Macedonia number currently returns `nil`. This adds a test for Macedonia, and also specifies the format for Macedonia.

Reference: https://en.wikipedia.org/wiki/Telephone_numbers_in_the_Republic_of_Macedonia