### PR TITLE
Upgrade rbx from 2 ~> 3 in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ rvm:
   - 2.0.0
   - 2.1.0
   - jruby-19mode
-  - rbx-2
+  - rbx-3
 
 script: rake


### PR DESCRIPTION
Attempting to fix Rubinius CI error by upgrading RBX in travis.yml:

```
1.21s$ gem install bundler
ERROR:  Loading command: install (LoadError::InvalidExtensionError)
	Could not open library /home/travis/.rvm/rubies/rbx-2/gems/gems/rubysl-openssl-2.8.0/lib/openssl/openssl.so - /home/travis/.rvm/rubies/rbx-2/gems/gems/rubysl-openssl-2.8.0/lib/openssl/openssl.so: symbol CRYPTO_memcmp, version OPENSSL_1.0.0 not defined in file libcrypto.so.1.0.0 with link time reference
ERROR:  While executing gem ... (NoMethodError)
    undefined method `invoke_with_build_args' on nil:NilClass.
```