### PR TITLE
Add validation for default country

### DIFF
--- a/Readme.rdoc
+++ b/Readme.rdoc
@@ -95,6 +95,10 @@ Similarly you can validate if a number is a mobile number via:
 
     validates :mobile_number, mobile_phone: true
 
+Similarly you can validate if a number is in your default country via:
+
+    validates :mobile_number, default_country_phone: true
+
 = TODO
 Add definitions for more countries
 

--- a/lib/phonie/phone.rb
+++ b/lib/phonie/phone.rb
@@ -65,6 +65,11 @@ module Phonie
       pn && pn.is_mobile?
     end
 
+    def self.is_default_country?(string, options = {})
+      pn = parse(string, options)
+      pn && pn.has_default_country_code?
+    end
+
     def area_code_long
       "0" + area_code if area_code
     end

--- a/lib/phonie/railties/locales/en.yml
+++ b/lib/phonie/railties/locales/en.yml
@@ -3,3 +3,4 @@ en:
     messages:
       invalid_phone_number: Invalid phone number
       invalid_mobile_phone_number: Invalid mobile phone number
+      invalid_country_phone_number: Invalid country code

--- a/lib/phonie/railties/locales/es.yml
+++ b/lib/phonie/railties/locales/es.yml
@@ -3,3 +3,4 @@ es:
     messages:
       invalid_phone_number: Teléfono inválido
       invalid_mobile_phone_number: Teléfono celular inválido
+      invalid_country_phone_number: Código de país inválido

--- a/lib/phonie/railties/locales/fr.yml
+++ b/lib/phonie/railties/locales/fr.yml
@@ -3,3 +3,5 @@ fr:
     messages:
       invalid_phone_number: Numéro de téléphone invalide
       invalid_mobile_phone_number: Téléphone cellulaire invalide
+      invalid_country_phone_number: Code de pays incorrect
+

--- a/lib/phonie/railties/locales/pt-BR.yml
+++ b/lib/phonie/railties/locales/pt-BR.yml
@@ -3,3 +3,5 @@ pt-BR:
     messages:
       invalid_phone_number: Número de telefone inválido
       invalid_mobile_phone_number: Número de celular inválido
+      invalid_country_phone_number: Código do país inválido
+

--- a/lib/phonie/railties/validator.rb
+++ b/lib/phonie/railties/validator.rb
@@ -11,3 +11,9 @@ class MobilePhoneValidator < ActiveModel::EachValidator
     object.errors.add(attribute, :invalid_mobile_phone_number) unless Phonie::Phone.valid?(value) && Phonie::Phone.is_mobile?(value)
   end
 end
+
+class DefaultCountryPhoneValidator < ActiveModel::EachValidator
+  def validate_each(object, attribute, value)
+    object.errors.add(attribute, :invalid_country_phone_number) unless Phonie::Phone.valid?(value) && Phonie::Phone.is_default_country?(value)
+  end
+end

--- a/test/phone_test.rb
+++ b/test/phone_test.rb
@@ -6,6 +6,12 @@ class PhoneTest < Phonie::TestCase
     assert Phonie::Phone.is_mobile?("918124452900")
   end
 
+  def test_is_default_country?
+    Phonie.configuration.default_country_code = '1'
+
+    assert Phonie::Phone.is_default_country?("18124452900")
+  end
+
   def test_number_without_country_code_initialize
     pn = Phonie::Phone.new '5125486', '91'
     assert !pn.valid?

--- a/test/railties/validator_test.rb
+++ b/test/railties/validator_test.rb
@@ -19,12 +19,19 @@ class SomeMobileModel < Struct.new(:mobile_number)
   validates :mobile_number, mobile_phone: true, allow_blank: true
 end
 
+class SomeCountryModel < Struct.new(:mobile_number)
+  include ActiveModel::Validations
+  validates :mobile_number, default_country_phone: true, allow_blank: true
+end
+
 class PhoneValidatorTest < Phonie::TestCase
   def test_blank_phone
     assert SomeModel.new(nil).invalid?
     assert SomeModel.new('').invalid?
     assert SomeOtherModel.new(nil).valid?
     assert SomeOtherModel.new('').valid?
+    assert SomeCountryModel.new(nil).valid?
+    assert SomeCountryModel.new('').valid?
   end
 
   def test_valid_model
@@ -47,6 +54,18 @@ class PhoneValidatorTest < Phonie::TestCase
   def test_mobile_validator
     valid = SomeMobileModel.new('+886952475345')
     invalid = SomeMobileModel.new('+886423194678')
+
+    assert valid.valid?
+    assert invalid.invalid?
+  end
+
+  def test_country_validator
+    Phonie.configuration.default_country_code = '1'
+
+    puts "DEFAULT: #{Phonie.configuration.default_country_code}"
+
+    valid = SomeCountryModel.new('+1 251 123 4567')
+    invalid = SomeCountryModel.new('+2 251 123 4567')
 
     assert valid.valid?
     assert invalid.invalid?


### PR DESCRIPTION
This adds the `default_country_phone` option to ActiveRecord validations

`validates :mobile_number, default_country_phone: true`